### PR TITLE
Maintain the insertion order of source files

### DIFF
--- a/cute/src/main/java/io/toolisticon/cute/impl/CompileTestConfiguration.java
+++ b/cute/src/main/java/io/toolisticon/cute/impl/CompileTestConfiguration.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -527,7 +528,7 @@ public class CompileTestConfiguration {
     /**
      * The source files to use.
      */
-    private final Set<JavaFileObject> sourceFiles = new HashSet<>();
+    private final Set<JavaFileObject> sourceFiles = new LinkedHashSet<>();
 
     /**
      * The processors to use.

--- a/cute/src/test/java/io/toolisticon/cute/impl/CompileTestConfigurationTest.java
+++ b/cute/src/test/java/io/toolisticon/cute/impl/CompileTestConfigurationTest.java
@@ -114,7 +114,7 @@ public class CompileTestConfigurationTest {
     }
 
     private void assertSourceFiles(CompileTestConfiguration configuration) {
-        MatcherAssert.assertThat(configuration.getSourceFiles(), Matchers.containsInAnyOrder(sourceJavaFileObject1, sourceJavaFileObject2, sourceJavaFileObject3));
+        MatcherAssert.assertThat(configuration.getSourceFiles(), Matchers.contains(sourceJavaFileObject1, sourceJavaFileObject2, sourceJavaFileObject3));
     }
 
 


### PR DESCRIPTION
In an annotation processor of mine I have to ensure that an annotation value is unique between different source files.

I created a test with CUTE that asserts that an error message is printed when the second source file is processed.
However, the test is unstable because the order of the source files varies inside CUTE.

I think it is reasonable that the source files are processed in the order they are specified. That is why I have made this small change.