### PR TITLE
Make processor method repeatable

### DIFF
--- a/cute/src/main/java/io/toolisticon/cute/CuteApi.java
+++ b/cute/src/main/java/io/toolisticon/cute/CuteApi.java
@@ -287,8 +287,8 @@ public class CuteApi {
 
     }
 
-    @FluentApiInterface(CompilerTestBB.class)
-    public interface BlackBoxTestProcessorsInterface {
+    public interface BlackBoxTestProcessorInterface
+    {
 
         /**
          * Allows you to add a single annotation processor used at black-box tests compilation.
@@ -296,8 +296,11 @@ public class CuteApi {
          * @param processor the annotation processor to use. null values are prohibited and will lead to a {@link io.toolisticon.fluapigen.validation.api.ValidatorException}.
          * @return the next fluent interface
          */
-        BlackBoxTestSourceFilesInterface processor(@FluentApiBackingBeanMapping(value = "processors")  @NotNull Class<? extends Processor> processor);
+        BlackBoxTestSourceFilesAndProcessorInterface processor(@FluentApiBackingBeanMapping(value = "processors") @NotNull Class<? extends Processor> processor);
+    }
 
+    @FluentApiInterface(CompilerTestBB.class)
+    public interface BlackBoxTestProcessorsInterface extends BlackBoxTestProcessorInterface{
 
         /**
          * Allows you to add annotation processors used at black-box tests compilation.
@@ -331,6 +334,9 @@ public class CuteApi {
         }
 
     }
+
+    @FluentApiInterface(CompilerTestBB.class)
+    public interface BlackBoxTestSourceFilesAndProcessorInterface extends BlackBoxTestProcessorInterface, BlackBoxTestSourceFilesInterface{}
 
     @FluentApiInterface(CompilerTestBB.class)
     public interface BlackBoxTestSourceFilesInterface {

--- a/cute/src/main/java/io/toolisticon/cute/CuteApi.java
+++ b/cute/src/main/java/io/toolisticon/cute/CuteApi.java
@@ -353,7 +353,7 @@ public class CuteApi {
          */
         // TODO: A validation if passed resource locations are correct would be good
         default BlackBoxTestFinalGivenInterface andSourceFiles(String... resources) {
-            return andSourceFiles(Arrays.stream(resources).map(e -> JavaFileObjectUtils.readFromResource(e)).toArray(JavaFileObject[]::new));
+            return andSourceFiles(Arrays.stream(resources).map(JavaFileObjectUtils::readFromResource).toArray(JavaFileObject[]::new));
         }
 
         /**
@@ -389,7 +389,7 @@ public class CuteApi {
          * @return the next fluent interface
          */
         default BlackBoxTestFinalGivenInterface andSourceFiles(@NotNull String... resources) {
-            return andSourceFiles(Arrays.stream(resources).map(e -> JavaFileObjectUtils.readFromResource(e)).toArray(String[]::new));
+            return andSourceFiles(Arrays.stream(resources).map(JavaFileObjectUtils::readFromResource).toArray(JavaFileObject[]::new));
         }
 
         /**

--- a/cute/src/main/java/io/toolisticon/cute/CuteApi.java
+++ b/cute/src/main/java/io/toolisticon/cute/CuteApi.java
@@ -25,7 +25,6 @@ import javax.tools.StandardLocation;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
@@ -48,7 +47,7 @@ public class CuteApi {
         UnitTestType getPassInType();
 
 
-        List<Class<Processor>> processors();
+        List<Class<? extends Processor>> processors();
 
         List<String> compilerOptions();
 
@@ -319,7 +318,7 @@ public class CuteApi {
          * @param processors the annotation processors to use. Passing an empty collection will compile the source files without using processors, null values are prohibited and will lead to a {@link io.toolisticon.fluapigen.validation.api.ValidatorException}.
          * @return the next fluent interface
          */
-        BlackBoxTestSourceFilesInterface processors(@FluentApiBackingBeanMapping(value = "processors")  @NotNull Collection<Class<? extends Processor>> processors);
+        BlackBoxTestSourceFilesInterface processors(@FluentApiBackingBeanMapping(value = "processors")  @NotNull Iterable<Class<? extends Processor>> processors);
 
         /**
          * More obvious method not to use processors during compilation.

--- a/cute/src/test/java/io/toolisticon/cute/CuteTest.java
+++ b/cute/src/test/java/io/toolisticon/cute/CuteTest.java
@@ -921,17 +921,17 @@ public class CuteTest {
 
     @Test(expected = ValidatorException.class)
     public void blackBoxTest_nullValuedProcessor() {
-        Cute.blackBoxTest().given().processor((Class<? extends Processor>)null);
+        Cute.blackBoxTest().given().processor(null);
     }
 
     @Test(expected = ValidatorException.class)
     public void blackBoxTest_nullValuedProcessors() {
-        Cute.blackBoxTest().given().processor((Class<? extends Processor>)null);
+        Cute.blackBoxTest().given().processors((Class<Processor>)null);
     }
 
     @Test(expected = ValidatorException.class)
     public void blackBoxTest_nullValuedProcessorInArray() {
-        Cute.blackBoxTest().given().processors((Class<? extends Processor>)null, (Class<? extends Processor>)null);
+        Cute.blackBoxTest().given().processors(null, null);
     }
 
     @Test(expected = ValidatorException.class)

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
         <!-- dependencies: compile and runtime -->
         <spiap.version>0.8.0</spiap.version>
-        <fluapigen.version>0.9.1</fluapigen.version>
+        <fluapigen.version>1.0.1-SNAPSHOT</fluapigen.version>
 
         <!-- versions of test dependencies -->
         <junit4.version>4.13.1</junit4.version>


### PR DESCRIPTION
Specifying multiple processors can be done by providing them as a Collection (but should be more general as an Iterable). On the other hand, it would be more "fluent" to support the processor method multiple times in the chain/flow.
This is an extension of #80. 