### PR TITLE
Fix NPE in CompilerMessage#getSource

### DIFF
--- a/cute/src/main/java/io/toolisticon/cute/CuteApi.java
+++ b/cute/src/main/java/io/toolisticon/cute/CuteApi.java
@@ -1556,10 +1556,15 @@ public class CuteApi {
         /**
          * Gets the source file name the compiler message is related with.
          *
-         * @return The source file name
+         * @return The source file name or {@code null} if no source object is associated
          */
         public String getSource() {
-            return diagnostic.getSource().getName();
+            JavaFileObject source = diagnostic.getSource();
+            if (source == null) {
+                return null;
+            }
+
+            return source.getName();
         }
 
 


### PR DESCRIPTION
Diagnostic#getSource() can return null if the message is not associated with a source object. This can cause NPEs when writing custom assertions for source files based on compiler messages and such a diagnostic is present.

I've not written tests for this simple change, but I can look into it if required.